### PR TITLE
Fix crash due to undefined destruction order

### DIFF
--- a/src/YDialog.cc
+++ b/src/YDialog.cc
@@ -49,8 +49,6 @@
 #define VERBOSE_EVENTS			0
 
 
-std::stack<YDialog *> YDialog::_dialogStack;
-
 typedef std::list<YEventFilter *> YEventFilterList;
 
 

--- a/src/YUI.cc
+++ b/src/YUI.cc
@@ -33,6 +33,8 @@
 #include <pthread.h>
 #include <stdlib.h>	// getenv()
 
+#include <stack>
+
 #define YUILogComponent "ui"
 #include "YUILog.h"
 
@@ -52,8 +54,13 @@ using std::endl;
 // (set to "KDE" or "GNOME" - case insensitive)
 #define ENV_BUTTON_ORDER "Y2_BUTTON_ORDER"
 
-
+// Keep dialog stack before the YUITerminator
+// so that it is destroyed afterwards.
+// YUITerminator deletes _yui which calls YUI::~YUI
+// which accesses the dialog stack to remove all dialogs
+std::stack<YDialog *> YDialog::_dialogStack;
 YUI * YUI::_ui = 0;
+
 static bool uiDeleted = false;
 
 extern void * start_ui_thread( void * yui );


### PR DESCRIPTION
YDialog has a static stack with all dialogs. YUI (singleton) destructor calls
YDialog::deleteAllDialogs which accesses the stack to delete all
dialogs.

The problem is that the YUI destructor is called from the static
YUITerminator destructor. We can't summe this is called before the
static dialog stack is destroyed.

So to fix it, move the definition of the dialog stack to the same YUI.cc
compilation unit, before the YUITerminator static, so that it is
destroyed afterwards.
