### PR TITLE
fix template-doc.spec.in

### DIFF
--- a/buildtools/template-doc.spec.in
+++ b/buildtools/template-doc.spec.in
@@ -53,7 +53,7 @@ This package provides the documentation. (HTML & PDF)
 export CFLAGS="$RPM_OPT_FLAGS -DNDEBUG"
 export CXXFLAGS="$RPM_OPT_FLAGS -DNDEBUG"
 
-./bootstrap %{_prefix}
+./bootstrap.sh %{_prefix}
 
 mkdir build
 cd build


### PR DESCRIPTION
it's not `bootstrap` but `bootstrap.sh` 
