### PR TITLE
libyui.spec.in: Use LFS_CFLAGS for 32bit arch LFS support.

### DIFF
--- a/libyui.spec.in
+++ b/libyui.spec.in
@@ -78,8 +78,8 @@ This package has very few dependencies.
 
 ./bootstrap.sh
 
-export CFLAGS="$RPM_OPT_FLAGS -DNDEBUG"
-export CXXFLAGS="$RPM_OPT_FLAGS -DNDEBUG"
+export CFLAGS="$RPM_OPT_FLAGS -DNDEBUG $(getconf LFS_CFLAGS)"
+export CXXFLAGS="$RPM_OPT_FLAGS -DNDEBUG $(getconf LFS_CFLAGS)"
 
 mkdir build
 cd build


### PR DESCRIPTION
In all 32bit archs, getconf LFS_CFLAGS returns proper flags to build the library with large file support just like the rest of the complete system.
