### PR TITLE
another fix for building tarball from git 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Sun Jun 30 18:52:25 CEST 2013 - anaselli@linux.it
+
+- git describe and git --tags do not always return a git hash
+  to avoid cmake failure a check has been introduced with a warning
+  message
+- skipping also .kdev4 when building source package
+
+-------------------------------------------------------------------
 Wed Jun 26 16:20:29 CEST 2013 - tgoettlicher@suse.de
 
 - Fixed build of libyui-qt-graph examples

--- a/buildtools/LibyuiCommon.cmake
+++ b/buildtools/LibyuiCommon.cmake
@@ -4,7 +4,6 @@
 ### and include it in CMakeLists.txt
 
 MACRO( SET_GITVERSION )
-
   FIND_PACKAGE( Git )
   IF( GIT_FOUND )
     EXEC_PROGRAM(
@@ -14,8 +13,14 @@ MACRO( SET_GITVERSION )
 	         OUTPUT_VARIABLE GIT_VERSION )
 
     STRING( REGEX MATCH "-g[0-9|a-f]+$" VERSION_SHA1 ${GIT_VERSION} )
-    STRING( REGEX REPLACE "[g]" "" VERSION_SHA1 ${VERSION_SHA1} )
-    SET(GIT_SHA1_VERSION "${VERSION_SHA1}")
+    IF ( VERSION_SHA1 )
+      STRING( REGEX REPLACE "[g]" "" VERSION_SHA1 ${VERSION_SHA1} )
+      SET(GIT_SHA1_VERSION "${VERSION_SHA1}")
+    ELSE( VERSION_SHA1 )
+	    MESSAGE ( WARNING "Cannot evaluate GIT_VERSION based on git
+	    describe --tags, skipping..." )
+      SET( GIT_SHA1_VERSION "" )
+    ENDIF( VERSION_SHA1 )
   ELSE( GIT_FOUND )
     MESSAGE ( STATUS "GIT_VERSION option needs git installed" )
     SET( GIT_SHA1_VERSION "" )
@@ -431,6 +436,7 @@ MACRO( PREP_OBS_TARBALL )	# prepare dist-tarball - This is a shameless rip-off f
     # backup files
     "~$"
     # eclipse files
+    "\\\\.kdev4$"
     "\\\\.cdtproject$"
     "\\\\.cproject$"
     "\\\\.project$"


### PR DESCRIPTION
- git describe and git --tags do not always return a git hash to avoid cmake failure a check has been introduced with 
  a warning message
- skipping also .kdev4 when building source package
