### PR TITLE
Fix build with clang

### DIFF
--- a/src/YAlignment.h
+++ b/src/YAlignment.h
@@ -28,7 +28,7 @@
 #include "YSingleChildContainerWidget.h"
 
 
-class YAlignmentPrivate;
+struct YAlignmentPrivate;
 
 /**
  * Implementation of all the alignment widgets:

--- a/src/YBarGraph.h
+++ b/src/YBarGraph.h
@@ -29,7 +29,7 @@
 #include "YColor.h"
 
 
-class YBarGraphPrivate;
+struct YBarGraphPrivate;
 class YBarGraphSegment;
 
 /**

--- a/src/YBusyIndicator.h
+++ b/src/YBusyIndicator.h
@@ -27,7 +27,7 @@
 
 #include "YWidget.h"
 
-class YBusyIndicatorPrivate;
+struct YBusyIndicatorPrivate;
 
 
 /**

--- a/src/YButtonBox.h
+++ b/src/YButtonBox.h
@@ -30,7 +30,7 @@
 #include "YWidget.h"
 #include "YPushButton.h"
 
-class YButtonBoxPrivate;
+struct YButtonBoxPrivate;
 class YPushButton;
 
 
@@ -147,7 +147,7 @@ struct YButtonBoxMargins
  **/
 class YButtonBox : public YWidget
 {
-    friend class YButtonBoxPrivate;
+    friend struct YButtonBoxPrivate;
 
 protected:
     /**

--- a/src/YCheckBox.h
+++ b/src/YCheckBox.h
@@ -30,7 +30,7 @@
 #include "YWidget.h"
 #include "ImplPtr.h"
 
-class YCheckBoxPrivate;
+struct YCheckBoxPrivate;
 
 enum YCheckBoxState
 {

--- a/src/YCheckBoxFrame.h
+++ b/src/YCheckBoxFrame.h
@@ -29,7 +29,7 @@
 #include "YSingleChildContainerWidget.h"
 #include "ImplPtr.h"
 
-class YCheckBoxFramePrivate;
+struct YCheckBoxFramePrivate;
 
 
 /**

--- a/src/YComboBox.h
+++ b/src/YComboBox.h
@@ -27,7 +27,7 @@
 
 #include "YSelectionWidget.h"
 
-class YComboBoxPrivate;
+struct YComboBoxPrivate;
 
 
 /**

--- a/src/YCommandLine.h
+++ b/src/YCommandLine.h
@@ -28,7 +28,7 @@
 #include <string>
 #include "ImplPtr.h"
 
-class YCommandLinePrivate;
+struct YCommandLinePrivate;
 
 
 /**

--- a/src/YContextMenu.h
+++ b/src/YContextMenu.h
@@ -29,7 +29,7 @@
 #include "YMenuItem.h"
 
 class YMenuItem;
-class YContextMenuPrivate;
+struct YContextMenuPrivate;
 
 
 /**

--- a/src/YDateField.h
+++ b/src/YDateField.h
@@ -27,7 +27,7 @@
 
 #include "YSimpleInputField.h"
 
-class YDateFieldPrivate;
+struct YDateFieldPrivate;
 
 /**
  * Input field for entering a date.

--- a/src/YDialog.h
+++ b/src/YDialog.h
@@ -32,7 +32,7 @@
 
 class YShortcutManager;
 class YPushButton;
-class YDialogPrivate;
+struct YDialogPrivate;
 class YEvent;
 class YEventFilter;
 

--- a/src/YDownloadProgress.h
+++ b/src/YDownloadProgress.h
@@ -28,7 +28,7 @@
 #include "YWidget.h"
 
 
-class YDownloadProgressPrivate;
+struct YDownloadProgressPrivate;
 
 /**
  * DownloadProgress: A progress bar that monitors downloading a file by

--- a/src/YDumbTab.h
+++ b/src/YDumbTab.h
@@ -27,7 +27,7 @@
 
 #include "YSelectionWidget.h"
 
-class YDumbTabPrivate;
+struct YDumbTabPrivate;
 
 /**
  * DumbTab: A very simple tab widget that can display and switch between a

--- a/src/YEmpty.h
+++ b/src/YEmpty.h
@@ -29,7 +29,7 @@
 #include "ImplPtr.h"
 
 
-class YEmptyPrivate;
+struct YEmptyPrivate;
 
 /**
  * A widget with zero size, useful as a placeholder.

--- a/src/YEventFilter.h
+++ b/src/YEventFilter.h
@@ -32,7 +32,7 @@
 class YEvent;
 class YDialog;
 
-class YEventFilterPrivate;
+struct YEventFilterPrivate;
 
 
 /**

--- a/src/YFrame.h
+++ b/src/YFrame.h
@@ -29,7 +29,7 @@
 #include "YSingleChildContainerWidget.h"
 #include "ImplPtr.h"
 
-class YFramePrivate;
+struct YFramePrivate;
 
 
 /**

--- a/src/YGraph.h
+++ b/src/YGraph.h
@@ -37,7 +37,7 @@
  * For that reason a lot of functions simply take a void* instead of graph_t*.
  */
 
-class YGraphPrivate;
+struct YGraphPrivate;
 
 /**
  * A graph with nodes and edges, rendered with Graphviz.

--- a/src/YImage.h
+++ b/src/YImage.h
@@ -29,7 +29,7 @@
 #include <string>
 
 
-class YImagePrivate;
+struct YImagePrivate;
 
 /**
  * A picture, possibly animated, loaded from a file.

--- a/src/YInputField.h
+++ b/src/YInputField.h
@@ -28,7 +28,7 @@
 #include <string>
 #include "YWidget.h"
 
-class YInputFieldPrivate;
+struct YInputFieldPrivate;
 
 
 

--- a/src/YIntField.h
+++ b/src/YIntField.h
@@ -27,7 +27,7 @@
 
 #include "YWidget.h"
 
-class YIntFieldPrivate;
+struct YIntFieldPrivate;
 
 
 

--- a/src/YLabel.h
+++ b/src/YLabel.h
@@ -30,7 +30,7 @@
 #include "ImplPtr.h"
 
 
-class YLabelPrivate;
+struct YLabelPrivate;
 
 /**
  * Implementation of the Label, Heading and OutputField widgets

--- a/src/YLayoutBox.h
+++ b/src/YLayoutBox.h
@@ -29,7 +29,7 @@
 #include "YWidget.h"
 
 
-class YLayoutBoxPrivate;
+struct YLayoutBoxPrivate;
 
 /**
  * A vertical or horizontal stacking of widgets, implementing HBox and VBox.

--- a/src/YLogView.h
+++ b/src/YLogView.h
@@ -27,7 +27,7 @@
 
 #include "YWidget.h"
 
-class YLogViewPrivate;
+struct YLogViewPrivate;
 
 
 /**

--- a/src/YMenuButton.h
+++ b/src/YMenuButton.h
@@ -29,7 +29,7 @@
 #include "YMenuItem.h"
 
 class YMenuItem;
-class YMenuButtonPrivate;
+struct YMenuButtonPrivate;
 
 
 /**

--- a/src/YMultiLineEdit.h
+++ b/src/YMultiLineEdit.h
@@ -27,7 +27,7 @@
 
 #include "YWidget.h"
 
-class YMultiLineEditPrivate;
+struct YMultiLineEditPrivate;
 
 /**
  * A multi-line plain-text area

--- a/src/YMultiProgressMeter.h
+++ b/src/YMultiProgressMeter.h
@@ -28,7 +28,7 @@
 #include "YWidget.h"
 #include <vector>
 
-class YMultiProgressMeterPrivate;
+struct YMultiProgressMeterPrivate;
 
 
 /**

--- a/src/YMultiSelectionBox.h
+++ b/src/YMultiSelectionBox.h
@@ -27,7 +27,7 @@
 
 #include "YSelectionWidget.h"
 
-class YMultiSelectionBoxPrivate;
+struct YMultiSelectionBoxPrivate;
 
 
 /**

--- a/src/YPartitionSplitter.h
+++ b/src/YPartitionSplitter.h
@@ -28,7 +28,7 @@
 #include "YWidget.h"
 
 
-class YPartitionSplitterPrivate;
+struct YPartitionSplitterPrivate;
 
 
 /**

--- a/src/YProgressBar.h
+++ b/src/YProgressBar.h
@@ -27,7 +27,7 @@
 
 #include "YWidget.h"
 
-class YProgressBarPrivate;
+struct YProgressBarPrivate;
 
 
 /**

--- a/src/YPushButton.h
+++ b/src/YPushButton.h
@@ -27,7 +27,7 @@
 
 #include "YWidget.h"
 
-class YPushButtonPrivate;
+struct YPushButtonPrivate;
 
 
 

--- a/src/YRadioButton.h
+++ b/src/YRadioButton.h
@@ -28,7 +28,7 @@
 #include "YWidget.h"
 
 class YRadioButtonGroup;
-class YRadioButtonPrivate;
+struct YRadioButtonPrivate;
 
 
 /**

--- a/src/YRadioButtonGroup.h
+++ b/src/YRadioButtonGroup.h
@@ -28,7 +28,7 @@
 #include "YSingleChildContainerWidget.h"
 
 class YRadioButton;
-class YRadioButtonGroupPrivate;
+struct YRadioButtonGroupPrivate;
 
 typedef std::list<YRadioButton *> 		YRadioButtonList;
 typedef YRadioButtonList::iterator		YRadioButtonListIterator;

--- a/src/YRichText.h
+++ b/src/YRichText.h
@@ -30,7 +30,7 @@
 #include "ImplPtr.h"
 
 
-class YRichTextPrivate;
+struct YRichTextPrivate;
 
 
 /**

--- a/src/YSelectionBox.h
+++ b/src/YSelectionBox.h
@@ -27,7 +27,7 @@
 
 #include "YSelectionWidget.h"
 
-class YSelectionBoxPrivate;
+struct YSelectionBoxPrivate;
 
 
 /**

--- a/src/YSelectionWidget.h
+++ b/src/YSelectionWidget.h
@@ -29,7 +29,7 @@
 #include "YItem.h"
 #include "ImplPtr.h"
 
-class YSelectionWidgetPrivate;
+struct YSelectionWidgetPrivate;
 
 /**
  * Base class for various kinds of multi-value widgets.

--- a/src/YSimpleInputField.h
+++ b/src/YSimpleInputField.h
@@ -27,7 +27,7 @@
 
 #include "YWidget.h"
 
-class YSimpleInputFieldPrivate;
+struct YSimpleInputFieldPrivate;
 
 
 /**

--- a/src/YSlider.h
+++ b/src/YSlider.h
@@ -27,7 +27,7 @@
 
 #include "YIntField.h"
 
-class YSliderPrivate;
+struct YSliderPrivate;
 
 
 /**

--- a/src/YSpacing.h
+++ b/src/YSpacing.h
@@ -28,7 +28,7 @@
 #include "YWidget.h"
 #include "ImplPtr.h"
 
-class YSpacingPrivate;
+struct YSpacingPrivate;
 
 
 /**

--- a/src/YSquash.h
+++ b/src/YSquash.h
@@ -29,7 +29,7 @@
 #include "ImplPtr.h"
 
 
-class YSquashPrivate;
+struct YSquashPrivate;
 
 /**
  * HSquash, VSquash HVSquash: reduce child to its preferred size.

--- a/src/YTable.h
+++ b/src/YTable.h
@@ -30,7 +30,7 @@
 #include "YTableItem.h"
 #include "YTableHeader.h"
 
-class YTablePrivate;
+struct YTablePrivate;
 
 
 

--- a/src/YTableHeader.h
+++ b/src/YTableHeader.h
@@ -31,7 +31,7 @@
 
 
 
-class YTableHeaderPrivate;
+struct YTableHeaderPrivate;
 
 /**
  * Helper class for YTable for table column properties:

--- a/src/YTimeField.h
+++ b/src/YTimeField.h
@@ -27,7 +27,7 @@
 
 #include "YSimpleInputField.h"
 
-class YTimeFieldPrivate;
+struct YTimeFieldPrivate;
 
 
 /**

--- a/src/YTimezoneSelector.cc
+++ b/src/YTimezoneSelector.cc
@@ -32,7 +32,7 @@
 
 class YTimezoneSelectorPrivate
 {
-   bool dummy;
+//   bool dummy;
 };
 
 

--- a/src/YTree.h
+++ b/src/YTree.h
@@ -28,7 +28,7 @@
 #include "YSelectionWidget.h"
 
 class YTreeItem;
-class YTreePrivate;
+struct YTreePrivate;
 
 
 /**

--- a/src/YUILog.h
+++ b/src/YUILog.h
@@ -64,7 +64,7 @@
 
 
 
-class YUILogPrivate;
+struct YUILogPrivate;
 
 enum YUILogLevel_t
 {

--- a/src/YWidget.h
+++ b/src/YWidget.h
@@ -45,7 +45,7 @@ typedef YChildrenManager<YWidget>	YWidgetChildrenManager;
 typedef YSingleChildManager<YWidget>	YSingleWidgetChildManager;
 typedef YChildrenRejector<YWidget>	YWidgetChildrenRejector;
 
-class YWidgetPrivate;
+struct YWidgetPrivate;
 
 
 /**

--- a/src/YWizard.h
+++ b/src/YWizard.h
@@ -28,7 +28,7 @@
 #include "YWidget.h"
 
 class YMacroRecorder;
-class YWizardPrivate;
+struct YWizardPrivate;
 class YPushButton;
 class YReplacePoint;
 


### PR DESCRIPTION
Fix warnings found with clang

error: class 'YButtonBoxPrivate' was previously declared as a struct [-Werror,-Wmismatched-tags]
|     friend class YButtonBoxPrivate;

YTimezoneSelector.cc:35:9: error: private field 'dummy' is not used [-Werror,-Wunused-private-field]
   bool dummy;
        ^

Signed-off-by: Khem Raj <raj.khem@gmail.com>